### PR TITLE
add encoding support for FieldNum >= 16 cases

### DIFF
--- a/js/protobuf.js
+++ b/js/protobuf.js
@@ -132,12 +132,24 @@ var Protobuf = {
      * https://developers.google.com/protocol-buffers/docs/encoding#structure.
      */
     encode: function(fields) {
-        var bstr = "", field, header, res;
+       var bstr = "", field, header, res, header1, plus;
         for (var i = 0, end = fields.length; i < end; i++) {
             field = fields[i];
             res = Protobuf.wire_encode(field[1]);
             header = (field[0] << 3) | res[0];
-            bstr += String.fromCharCode(header) + res[1](field[2]);
+          
+            // when FieldNum >= 16 , header will be greater than 128, which will cause encoding problem
+            // add a second header here
+            header1 = Math.floor(field[0] / 16);
+          
+            if (header1 > 0) {
+                header = header - 128 * (header1 - 1);
+                plus = String.fromCharCode(header, header1) + res[1](field[2]);
+            } else {
+                plus = String.fromCharCode(header) + res[1](field[2]);
+            }
+            
+            bstr += plus;
         }
         return bstr;
     },


### PR DESCRIPTION
This is the same with https://github.com/kolorahl/jsbuf/pull/3

When FieldNum >= 16 , header will be greater than 128, which will cause encoding problem.
The header now should take two charcode.

For example header 256 will be (128, 1), header 385 wil be (129, 2)
(Compared with dcodeIO/ProtoBuf.js I found the result, I'm not 100% sure)

I made two demos about this.

http://jsbin.com/wipoyo/6/watch?js,console (origin)

http://jsbin.com/nakusi/2/watch?js,console (after)
